### PR TITLE
Add 2024 Champions Program Blog Post

### DIFF
--- a/content/blog/2024-04-18-champions-program-2024/index.md
+++ b/content/blog/2024-04-18-champions-program-2024/index.md
@@ -1,0 +1,58 @@
+---
+title: Announcing the rOpenSci Champions Program! 
+author: Yanina Bellini Saibene
+date: '2024-04-18'
+tags:
+  - Community
+  - champions program
+  - English
+description: We are thrilled to launch our Champions Program pilot!
+---
+
+[Entrada en español](/blog/2024/04/18/launch-champions-program-es/)
+
+> We are thrilled to launch our Champions Program pilot!
+
+## Why a Champions Program?
+
+Champion programs are designed to identify, recognize, and reward passionate community members.
+
+At rOpenSci, we recognize that there is a dismaying lack of diversity in the ecosystem of research software and open source communities. The R Community is no exception; its developers are overwhelmingly white, male, and from a handful of countries. This disappointing lack of diversity is potentially detrimental to the sustainability, utility and productivity of projects. 
+
+We also know that communities of practice can drive meaningful change. We understand the importance of supporting a diverse cohort of community leaders and contributors to all aspects of research software creation as they strive to transform our ecosystem for the better.
+
+The rOpenSci Champion Program [is part of a series of activities and projects we are carrying out to ensure our research software serves everyone in our communities](https://ropensci.org/blog/2021/12/20/inclusive-leadership-program/), which means that it needs to be sustainable and open, and built __by and for all groups.__
+
+That is why this program focuses on __people who belong to groups that are historically and systematically excluded__ from the open software and research software communities and who are interested in contributing to rOpenSci and the broader ecosystem of open source and research software communities.
+
+## What is our Champions Program?
+
+We have developed a **12-month-long program including cohort-based training, project development, and personal mentorship**. 
+
+Champions will participate in a 6-week long cohort-based training on a) planning and facilitating engaging and inclusive workshops to support participants’ success, b) knowledge of various channels through which new members can engage in and contribute to rOpenSci and R projects, and c) technical skills in software development and review. 
+
+After training, Champions will develop their project, which can be one of the following options:
+
+* Create a new package;
+* Go through the review process with an R package they have already developed;
+* Serve as a reviewer for the rOpenSci software peer review system.
+
+Mentors may also support Champions with delivering other activities including: giving a talk, writing blog posts, and teaching other community members.
+
+We will provide a $1000 (USD) stipend to the selected community champions.
+
+You can see all details on our [Champions Program webpage](https://ropensci.org/champions/).
+
+## How to apply?
+
+Please, fill out the [application form](https://airtable.com/shrAsYlSXU0coJ5Ld) (this [template shows the information we will require](https://ropensci.org/champions/files/champions_template)) by __Friday, Nov 7, 2024__. The application forms have to be completed _in English_.
+
+## Do you have any questions? 
+
+Please, contact our Community Manager by [email](mailto:yabellini@ropensci.org) or [book a 15 minutes meeting with her](https://calendly.com/yabellini-ropensci/15min).
+
+We will have a [Community Call on October 24th](https://ropensci.org/commcalls/oct2024-champions/)to explain and explore the benefits of Champions Programs and a [Coworking slot on November 1st](https://ropensci.org/events/coworking-2024-11/) to answer any questions you might have about mentoring in this program.
+
+**We look forward to meeting all of you passionate Champions out there :-D**
+
+_This content was first posted on [rOpenSci](https://ropensci.org/blog/2024/04/18/launch-champions-program/)._


### PR DESCRIPTION
Adds a new blog post to the `yabellini/SitioAcademico` repository, detailing the launch of the rOpenSci Champions Program.

- **Content Addition**: Introduces the blog post content from the provided URL, including details about the program, how to apply, and contact information.
- **Attribution Note**: Includes a statement at the end of the post acknowledging that the content was originally posted on rOpenSci, with a link to the original post.
- **Featured Image**: The plan to add a featured image is mentioned, but the actual code or markdown for adding an image is not present in the provided content.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yabellini/SitioAcademico?shareId=f66837f5-73fb-4332-9727-ff95e537b25c).