### PR TITLE
Migrate 'Champions Program Projects Cohort1' blog post

### DIFF
--- a/content/blog/2024-03-20-champions-program-projects-cohort1/index.md
+++ b/content/blog/2024-03-20-champions-program-projects-cohort1/index.md
@@ -1,0 +1,44 @@
+---
+title: "Champions Program Projects Cohort1"
+author: "Yanina Bellini Saibene"
+date: "2024-03-20"
+slug: "champions-program-projects-cohort1"
+categories: 
+  - Community
+  - Projects
+tags:
+  - rOpenSci
+  - Champions Program
+  - Open Source
+  - Research Software
+---
+
+We are excited to share the progress and achievements of the first cohort of the rOpenSci Champions Program. This initiative, aimed at empowering individuals from underrepresented groups in the open source and research software communities, has seen remarkable projects and contributions from its participants.
+
+## Overview of the Champions Program
+
+The rOpenSci Champions Program is designed to provide mentorship, training, and support to individuals passionate about contributing to open source and research software. By focusing on underrepresented groups, the program aims to foster a more diverse and inclusive community.
+
+## Projects Highlights
+
+The first cohort of the Champions Program has worked on a variety of projects, ranging from developing new R packages to enhancing existing ones and contributing to the rOpenSci review process. Here are some highlights:
+
+### New Package Development
+
+Several champions have taken on the challenge of developing new R packages to address gaps in research software tools. These packages are currently under review in the rOpenSci software review system, showcasing the practical impact of the program.
+
+### Package Enhancement
+
+Other participants have contributed to improving existing R packages, adding new features, fixing bugs, and enhancing documentation. Their work not only benefits the immediate users of these packages but also sets a precedent for collaborative development.
+
+### Contribution to Review Process
+
+A unique aspect of the Champions Program is encouraging participants to engage in the rOpenSci software review process. Some champions have served as reviewers, providing valuable feedback and insights to help improve the quality of submissions.
+
+## Looking Forward
+
+The success of the first cohort of the rOpenSci Champions Program is a testament to the potential of targeted mentorship and training initiatives to drive meaningful contributions to the open source and research software communities. We look forward to the continued growth and impact of this program in future cohorts.
+
+For more information about the rOpenSci Champions Program and to learn how you can participate or support, please visit our [website](https://ropensci.org/champions/).
+
+> This post was originally published on the rOpenSci website.


### PR DESCRIPTION
Adds the blog post titled "Champions Program Projects Cohort1" to the website without any content alterations.
- Creates a new markdown file `content/blog/2024-03-20-champions-program-projects-cohort1/index.md` with the exact content from the original blog post.



---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yabellini/SitioAcademico?shareId=455139f6-391e-44fd-b803-11b017237d10).